### PR TITLE
Post call for new coordos

### DIFF
--- a/content/english/news/04082022.md
+++ b/content/english/news/04082022.md
@@ -1,0 +1,64 @@
+---
+author: QCBS R Workshop Series
+bg_image: images/feature-bg.jpg
+categories: Calls
+date: "2022-08-04"
+description: 
+draft: false
+#image: images/blog/blog-post-1.jpg
+tags:
+- Calls
+title: Call for new R Workshop Series Coordination Team
+type: post
+---
+ 
+We are opening a call for the recruitment of <b>three</b> coordinators for the QCBS R Workshop Series, to start their term this next September, 2022.
+ 
+### Responsibilities
+ 
+The upcoming coordinators must ensure the organization and execution of the QCBS R Workshop Series and QCBS R Symposia. 
+ 
++ Coordinators share responsibilities that include:
++ Meeting periodically (weekly or bi-weekly) to discuss and implement actions related to the coordination of the R Workshop Series and the Symposia;
++ Writing the annual budget that must be sent, discussed with, and approved by the QCBS directorship;
++ Communicating frequently with theQCBS administrationve associates, representative members, members from the QCBS on matters related to R Workshop Series;
++ Organizing the annual R Workshop Series and R Symposium;
++ Recruiting QCBS members to contribute to the R Workshop Series by presenting workshops and/or by developing the presentation and written materials;
++ Communicating with the QCBS administration to ensure that contributing members to the R Workshop Series receive their Learning and Development Awards;
++ Ensuring that the website and the presenter and developer protocols are up-to-date;
++ Assessing, and if possible, implementing new projects related to the R Workshop Series;
+ 
+The current coordinators will ensure a smooth transition of tasks to the upcoming coordinators.
+ 
+### Requirements
+ 
+It is indispensable that coordinators proactively maintain a respectiful, collaborative and inclusive environment and follow institutional codes of conduct related to the QCBS and the QCBS R Workshop Series.
+ 
+Prospective coordinators must be active members from the QCBS, and must be willing to learn and to use tools required to maintain the Series and the Symposia (e.g., R, GitHub, Zoom Meetings, and Slack).
+ 
+### Preference
+ 
+Preference will be given to forming a diverse coordination cohort with members willing to take the position for two consecutive years and that can be bilingual.
+ 
+### Award
+ 
+Coordinators receive a Learning and Development Award of $2,000 per year that respect the <a href = "https://r.qcbs.ca/presenter-developer-protocol/payment-en.html">award payment guidelines</a> from the QCBS R Workshop Series.
+ 
+### Application
+ 
+If you are interested in applying please respond back to this message <b>by August 21st, 2022</b>.
+ 
+We will get back to you with further details on the application process.
+ 
+Do not hesitate to contact us if you have any questions.
+ 
+Wishing you all a wonderful rest of the summer,
+
+The QCBS R Workshop Series coordination team
+
+Pedro Henrique P. Braga (ph.pereirabraga@gmail.com)
+Katherine Hébert (katherine.hebert@usherbrooke.ca)
+Linley Sherin ()
+Esteban Gongora Bernoske
+
+

--- a/content/french/news/04082022.md
+++ b/content/french/news/04082022.md
@@ -1,0 +1,63 @@
+---
+author: Série d'ateliers R du CSBQ
+bg_image: images/feature-bg.jpg
+categories:
+- Appels
+date: "2022-08-04"
+description: 
+draft: false
+#image: images/blog/blog-post-1.jpg
+tags:
+- Appels
+title: Appel pour une nouvelle équipe de coordination de la Série d'ateliers R
+type: post
+---
+
+Nous lançons un appel pour le recrutement de <b>trois personnes</b> pour coordonner la série d'ateliers R du CSBQ, pour commencer leur mandat en septembre 2022.
+
+### Responsabilités
+ 
+La prochaine équipe de coordination devra assurer l'organisation et l'exécution de la série d'ateliers R du CSBQ et des colloques R du CSBQ. 
+ 
+L’équipe de coordination partage des responsabilités qui incluent :
+
++ Se rencontrer périodiquement (hebdomadairement ou bihebdomadairement) pour discuter et mettre en œuvre les actions liées à la coordination de la série d'ateliers R et des colloques ;
++ Rédiger le budget annuel qui doit être envoyé, discuté et approuvé par la direction du CSBQ ;
++ Communiquer fréquemment avec l’équipe administrative du CSBQ, les membres représentatifs, les membres du CSBQ sur les questions relatives à la série d'ateliers R ;
++ Organiser la série d'ateliers R et le Colloque R annuels ;
++ Recruter des membres du CSBQ pour contribuer à la série d'ateliers R en présentant des ateliers et/ou en développant la présentation et le matériel écrit ;
++ Communiquer avec l'administration du CSBQ pour s'assurer que les membres qui contribuent à la série d'ateliers R reçoivent leurs bourses d'apprentissage et de développement ;
++ S'assurer que le site web et les protocoles de présentation et de développement sont à jour ;
++ Évaluer, et si possible, mettre en œuvre de nouveaux projets liés à la série d'ateliers R ;
++ Identifier, recruter et former la prochaine équipe de coordination de la série d'ateliers R.
+ 
+L’équipe de coordination actuelle assurera une transition en douceur des tâches à la prochaine équipe.
+
+### Préférence
+ 
+La préférence sera donnée à la formation d'une cohorte de coordination diversifiée dont les membres sont prêts à prendre le poste pendant deux années consécutives et qui peuvent être bilingues.
+
+### Exigences
+ 
+Il est indispensable que la coordination maintienne de manière proactive un environnement respectueux, collaboratif et inclusif et qu'elle suive les codes de conduite institutionnels relatifs au CSBQ et à la Série d'ateliers R du CSBQ.
+ 
+Les personnes intéressées à la coordination doivent être des membres actifs du CSBQ, et doivent être prêtes à apprendre et à utiliser les outils nécessaires au maintien de la série et des colloques (par exemple, R, GitHub, Zoom, et Slack).
+
+### Prix
+ 
+Les coordonnateurs et coordinatrices reçoivent un prix d'apprentissage et de développement de 2 000 $ par année qui respecte les <a href = "https://r.qcbs.ca/presenter-developer-protocol/payment-fr.html">directives de paiement</a> du prix de la série d'ateliers R du CSBQ.
+ 
+### Postuler
+ 
+Si vous souhaitez postuler, veuillez répondre à ce message <b>avant le 21 août 2022</b>.
+ 
+Nous vous contacterons avec plus de détails sur le processus de candidature.
+ 
+N'hésitez pas à nous contacter si vous avez des questions.
+ 
+Avec nos meilleures salutations,
+ 
+Pedro Henrique P. Braga (ph.pereirabraga@gmail.com)
+Katherine Hébert (katherine.hebert@usherbrooke.ca)
+Linley Sherin ()
+Esteban Gongora Bernoske


### PR DESCRIPTION
This PR adds a News post with the information about the call for new coordinators for the Series (in the French and English versions of the website). We can merge it when we are ready to publicize the call.